### PR TITLE
ステージセレクトの設計修正に伴い、ポーズ画面から戻った時に次のステージが仮選択されるバグを修正、なぜかステージ２０だけポーズメニューの参照…

### DIFF
--- a/Assets/Scenes/Stage/stage20.unity
+++ b/Assets/Scenes/Stage/stage20.unity
@@ -366,6 +366,11 @@ Prefab:
       propertyPath: _skipButton
       value: 
       objectReference: {fileID: 1007591508}
+    - target: {fileID: 114222517673691712, guid: f5f986a361e915941859d1fffeb2df9c,
+        type: 2}
+      propertyPath: canvas
+      value: 
+      objectReference: {fileID: 802046588}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f5f986a361e915941859d1fffeb2df9c, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scripts/Gucchi/StageSelectManager.cs
+++ b/Assets/Scripts/Gucchi/StageSelectManager.cs
@@ -75,15 +75,14 @@ namespace GucchiCS
             }
 
             // 前回遊んだステージの次のステージを仮選択しておく
-            int beforeStageNo = StageNoReader._stageNo % _doors.Count;
-            if (beforeStageNo == 0)
-                beforeStageNo = 1;
+            int beforeStageNo = (StageNoReader._stageNo - 1) % _doors.Count;
 
-            // 初期の仮選択を設定（クリアした後なら次のステージ、そうでないなら前回のステージまたは１ステージ）
+            // クリアした後かどうかで仮選択させるステージの番号を変更
             if (StageNoReader._isClear)
-                _selectedDoor = _doors[beforeStageNo];
-            else
-                _selectedDoor = _doors[beforeStageNo - 1];
+                beforeStageNo = (++beforeStageNo) % _doors.Count;
+
+            // 初期の仮選択を設定
+            _selectedDoor = _doors[beforeStageNo];
             _selectedDoor.OnSelectEnter();
 
             // 仮選択ステージによってブロック位置を変更


### PR DESCRIPTION
…がはずれていたのを修正